### PR TITLE
Added custom GlyphData.xml file.

### DIFF
--- a/sources/README.md
+++ b/sources/README.md
@@ -1,0 +1,1 @@
+To generate the fonts with Glyphsapp, replace the GlyphData.xml file in this dir with the one Glyphsapp uses, https://glyphsapp.com/tutorials/roll-your-own-glyph-data


### PR DESCRIPTION
In newer versions of Glyphsapp, they have deprecated some unicodes on
ligatures. This GlyphsData.xml reincludes those codepoints.

https://forum.glyphsapp.com/t/ligature-unicodes-for-f-f-f-l/8255

